### PR TITLE
Split module into code and data components.

### DIFF
--- a/client/protos/remote_torch.proto
+++ b/client/protos/remote_torch.proto
@@ -48,6 +48,8 @@ message TrainConfig {
     float eps = 7;
     float max_grad_norm = 8;
     float metric_eps = 9;
+    int32 per_n_step_checkpoint = 12;
+    bool per_epoch_checkpoint = 13;
     
     oneof optimizer {
         // The type of optimizer to be used during training.

--- a/examples/dp_sgd_linear_regression.py
+++ b/examples/dp_sgd_linear_regression.py
@@ -51,7 +51,13 @@ with Connection("localhost", 50051) as client:
 
     print(f"Optimizers: {(client.get_available_optimizers())}")
 
-    remote_learner.fit(nb_epochs=200, eps=300.0, metric_eps=8000.0)
+    remote_learner.fit(
+        nb_epochs=200,
+        eps=300.0,
+        metric_eps=8000.0,
+        per_epoch_checkpoint=False,
+        per_n_step_checkpoint=2,
+    )
 
     lreg_model = remote_learner.get_model()
 

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -98,7 +98,7 @@ checksum = "8a32fd6af2b5827bce66c29053ba0e7c42b9dcab01835835058558c10851a46b"
 
 [[package]]
 name = "bastionai_app"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "bastionai_common",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "bastionai_common"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "http",
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "bastionai_learning"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "libc",
  "rand",

--- a/server/bastionai_app/src/main.rs
+++ b/server/bastionai_app/src/main.rs
@@ -273,6 +273,14 @@ impl RemoteTorch for BastionAIServer {
             .unwrap()
             .insert(identifier, Arc::new(RwLock::new(Run::Pending)));
         let run = Arc::clone(self.runs.read().unwrap().get(&identifier).unwrap());
+        let chkpt_setting = if config.per_epoch_checkpoint {
+            String::from("Checkpoint per epoch")
+        }else if config.per_n_step_checkpoint > 0 {
+            String::from(format!("Checkpoint per {} steps", config.per_n_step_checkpoint))
+        }else {
+            String::from("Checkpoint at the end of training!")
+        };
+        info!(target: "BastionAI", "{}",chkpt_setting );
         module_train(binary, dataset, run, config, device, binary_id, dataset_id, client_info, chkpt);
         Ok(Response::new(Reference {
             identifier: format!("{}", identifier),

--- a/server/bastionai_app/src/storage.rs
+++ b/server/bastionai_app/src/storage.rs
@@ -17,6 +17,19 @@ pub struct Artifact<T> {
     pub client_info: Option<ClientInfo>,
 }
 
+impl<T: Default> Default for Artifact<T> {
+    fn default() -> Self {
+        Self {
+            description: String::default(),
+            name: String::default(),
+            secret: hmac::Key::new(ring::hmac::HMAC_SHA256, &[0]),
+            meta: Vec::default(),
+            client_info: None,
+            data: Arc::default(),
+        }
+    }
+}
+
 // impl<T> Artifact<T> {
 //     /// Verifies passed meassage and tag against stored owner key.
 //     pub fn verify(&self, msg: &[u8], tag: &[u8]) -> bool {

--- a/server/bastionai_learning/src/lib.rs
+++ b/server/bastionai_learning/src/lib.rs
@@ -13,7 +13,7 @@ mod tests {
     use crate::data::privacy_guard::{
         BatchDependence, PrivacyBudget, PrivacyContext, PrivacyGuard,
     };
-    use crate::nn::{CheckPoint, LossType, Module};
+    use crate::nn::{LossType, Module};
     use crate::optim::{Optimizer, SGD};
 
     fn l2_loss(output: &Tensor, target: &Tensor) -> Result<Tensor, TchError> {
@@ -59,8 +59,8 @@ mod tests {
     fn basic_sgd() {
         let mut module = Module::load_from_file("lreg_base.pt", Device::Cpu).unwrap();
         let (forward, parameters) = module.parameters();
-        let mut chkpt = CheckPoint::new();
-        let mut optimizer = SGD::new(parameters, &mut chkpt, 0.1);
+        // let mut chkpt = CheckPoint::new();
+        let mut optimizer = SGD::new(parameters, 0.1);
 
         let data = vec![
             Tensor::of_slice::<f32>(&[0.]),
@@ -98,9 +98,9 @@ mod tests {
     fn private_sgd() {
         let mut module = Module::load_from_file("lreg.pt", Device::Cpu).unwrap();
         let (forward, parameters) = module.private_parameters(30.0, 1.0, LossType::Mean(2));
-        let mut chkpt = CheckPoint::new();
+        // let mut chkpt = CheckPoint::new();
 
-        let mut optimizer = SGD::new(parameters, &mut chkpt, 0.1);
+        let mut optimizer = SGD::new(parameters, 0.1);
 
         let data = vec![
             Tensor::of_slice::<f32>(&[0.0, 1.0]).f_view([2, 1]).unwrap(),

--- a/server/bastionai_learning/src/lib.rs
+++ b/server/bastionai_learning/src/lib.rs
@@ -1,21 +1,26 @@
-pub mod optim;
-pub mod nn;
-pub mod serialization;
-pub mod procedures;
 pub mod data;
+pub mod nn;
+pub mod optim;
+pub mod procedures;
+pub mod serialization;
 
 #[cfg(test)]
 mod tests {
-    use tch::{TrainableCModule, Device, Tensor, TchError, Kind};
-    use tch::nn::VarStore;
     use std::sync::{Arc, RwLock};
+    use tch::nn::VarStore;
+    use tch::{Device, Kind, TchError, Tensor, TrainableCModule};
 
-    use crate::data::privacy_guard::{PrivacyContext, PrivacyBudget, PrivacyGuard, BatchDependence};
-    use crate::nn::{LossType, Module};
-    use crate::optim::{SGD, Optimizer};
+    use crate::data::privacy_guard::{
+        BatchDependence, PrivacyBudget, PrivacyContext, PrivacyGuard,
+    };
+    use crate::nn::{CheckPoint, LossType, Module};
+    use crate::optim::{Optimizer, SGD};
 
     fn l2_loss(output: &Tensor, target: &Tensor) -> Result<Tensor, TchError> {
-        output.f_sub(&target)?.f_norm_scalaropt_dim(2, &[1], false)?.f_mean(Kind::Float)
+        output
+            .f_sub(&target)?
+            .f_norm_scalaropt_dim(2, &[1], false)?
+            .f_mean(Kind::Float)
     }
 
     #[test]
@@ -54,7 +59,8 @@ mod tests {
     fn basic_sgd() {
         let mut module = Module::load_from_file("lreg_base.pt", Device::Cpu).unwrap();
         let (forward, parameters) = module.parameters();
-        let mut optimizer = SGD::new(parameters, 0.1);
+        let mut chkpt = CheckPoint::new();
+        let mut optimizer = SGD::new(parameters, &mut chkpt, 0.1);
 
         let data = vec![
             Tensor::of_slice::<f32>(&[0.]),
@@ -65,14 +71,20 @@ mod tests {
             Tensor::of_slice::<f32>(&[2.]),
         ];
 
-        let context = Arc::new(RwLock::new(PrivacyContext::new(PrivacyBudget::NotPrivate, 4)));
+        let context = Arc::new(RwLock::new(PrivacyContext::new(
+            PrivacyBudget::NotPrivate,
+            4,
+        )));
 
         for _ in 0..100 {
             for (x, t) in data.iter().zip(target.iter()) {
                 let x = PrivacyGuard::new(x.copy(), BatchDependence::Dependent, context.clone());
                 let t = PrivacyGuard::new(t.copy(), BatchDependence::Dependent, context.clone());
                 let y = forward.forward(vec![x]).unwrap();
-                let loss = y.f_mse_loss(&t, (0.0, 10.0), tch::Reduction::Mean).unwrap().0;
+                let loss = y
+                    .f_mse_loss(&t, (0.0, 10.0), tch::Reduction::Mean)
+                    .unwrap()
+                    .0;
                 optimizer.zero_grad().unwrap();
                 loss.backward();
                 optimizer.step().unwrap();
@@ -86,7 +98,9 @@ mod tests {
     fn private_sgd() {
         let mut module = Module::load_from_file("lreg.pt", Device::Cpu).unwrap();
         let (forward, parameters) = module.private_parameters(30.0, 1.0, LossType::Mean(2));
-        let mut optimizer = SGD::new(parameters, 0.1);
+        let mut chkpt = CheckPoint::new();
+
+        let mut optimizer = SGD::new(parameters, &mut chkpt, 0.1);
 
         let data = vec![
             Tensor::of_slice::<f32>(&[0.0, 1.0]).f_view([2, 1]).unwrap(),
@@ -97,15 +111,21 @@ mod tests {
             Tensor::of_slice::<f32>(&[1.0, 0.4]).f_view([2, 1]).unwrap(),
         ];
 
-        let context = Arc::new(RwLock::new(PrivacyContext::new(PrivacyBudget::Private(300.1), 4)));
-        
+        let context = Arc::new(RwLock::new(PrivacyContext::new(
+            PrivacyBudget::Private(300.1),
+            4,
+        )));
+
         for _ in 0..200 {
             for (x, t) in data.iter().zip(target.iter()) {
                 let x = PrivacyGuard::new(x.copy(), BatchDependence::Dependent, context.clone());
                 let t = PrivacyGuard::new(t.copy(), BatchDependence::Dependent, context.clone());
 
                 let y = forward.forward(vec![x]).unwrap();
-                let loss = y.f_mse_loss(&t, (0.0, 10.0), tch::Reduction::Mean).unwrap().0;
+                let loss = y
+                    .f_mse_loss(&t, (0.0, 10.0), tch::Reduction::Mean)
+                    .unwrap()
+                    .0;
                 optimizer.zero_grad().unwrap();
                 loss.backward();
                 optimizer.step().unwrap();
@@ -113,7 +133,11 @@ mod tests {
         }
         let w = &optimizer.parameters.into_inner().unwrap()[0];
         w.print();
-        assert!(l2_loss(w, &Tensor::of_slice::<f32>(&[2.])).unwrap().double_value(&[]) < 0.1);
+        assert!(
+            l2_loss(w, &Tensor::of_slice::<f32>(&[2.]))
+                .unwrap()
+                .double_value(&[])
+                < 0.1
+        );
     }
-
 }

--- a/server/bastionai_learning/src/nn/mod.rs
+++ b/server/bastionai_learning/src/nn/mod.rs
@@ -1,5 +1,5 @@
-mod parameters;
 mod module;
+mod parameters;
 
-pub use parameters::{Parameters, LossType};
-pub use module::{Module, Forward};
+pub use module::{CheckPoint, Forward, Module};
+pub use parameters::{LossType, Parameters};

--- a/server/bastionai_learning/src/optim/adam.rs
+++ b/server/bastionai_learning/src/optim/adam.rs
@@ -1,5 +1,5 @@
-use super::{initialize_statistics, log_checkpoint, Optimizer};
-use crate::nn::{CheckPoint, Parameters};
+use super::{initialize_statistics, Optimizer};
+use crate::nn::Parameters;
 use tch::{TchError, Tensor};
 
 /// Adam Optimizer
@@ -20,11 +20,10 @@ pub struct Adam<'a> {
     v_hat_max: Vec<Option<Tensor>>,
     t: i32,
     pub parameters: Parameters<'a>,
-    chkpt: &'a mut CheckPoint,
 }
 
 impl<'a> Adam<'a> {
-    pub fn new(parameters: Parameters<'a>, chkpt: &'a mut CheckPoint, learning_rate: f64) -> Self {
+    pub fn new(parameters: Parameters<'a>, learning_rate: f64) -> Self {
         Adam {
             learning_rate: learning_rate,
             beta_1: 0.9,
@@ -37,7 +36,6 @@ impl<'a> Adam<'a> {
             v_hat_max: initialize_statistics(parameters.len()),
             t: 1,
             parameters,
-            chkpt,
         }
     }
     pub fn beta_1(mut self, beta_1: f64) -> Self {
@@ -128,10 +126,7 @@ impl<'a> Optimizer for Adam<'a> {
         })
     }
 
-    fn check_point(&mut self) -> Result<(), TchError> {
-        self.chkpt.append(&mut log_checkpoint(
-            self.parameters.into_named_inner().unwrap(),
-        ));
-        Ok(())
+    fn into_bytes(&mut self) -> Result<Vec<u8>, TchError> {
+        self.parameters.into_bytes()
     }
 }

--- a/server/bastionai_learning/src/optim/mod.rs
+++ b/server/bastionai_learning/src/optim/mod.rs
@@ -1,5 +1,3 @@
-use std::sync::Mutex;
-
 use tch::Tensor;
 
 mod adam;
@@ -14,15 +12,6 @@ fn initialize_statistics(length: usize) -> Vec<Option<Tensor>> {
     v
 }
 
-pub fn log_checkpoint(inner_params: Vec<(String, Tensor)>) -> CheckPoint {
-    inner_params
-        .iter()
-        .map(|(n, v)| (n.clone(), Mutex::new(v.copy().f_detach_().unwrap())))
-        .collect()
-}
-
 pub use adam::Adam;
 pub use optimizer::Optimizer;
 pub use sgd::SGD;
-
-use crate::nn::CheckPoint;

--- a/server/bastionai_learning/src/optim/mod.rs
+++ b/server/bastionai_learning/src/optim/mod.rs
@@ -1,8 +1,10 @@
+use std::sync::Mutex;
+
 use tch::Tensor;
 
+mod adam;
 mod optimizer;
 mod sgd;
-mod adam;
 
 fn initialize_statistics(length: usize) -> Vec<Option<Tensor>> {
     let mut v = Vec::with_capacity(length);
@@ -12,6 +14,15 @@ fn initialize_statistics(length: usize) -> Vec<Option<Tensor>> {
     v
 }
 
+pub fn log_checkpoint(inner_params: Vec<(String, Tensor)>) -> CheckPoint {
+    inner_params
+        .iter()
+        .map(|(n, v)| (n.clone(), Mutex::new(v.copy().f_detach_().unwrap())))
+        .collect()
+}
+
+pub use adam::Adam;
 pub use optimizer::Optimizer;
 pub use sgd::SGD;
-pub use adam::Adam;
+
+use crate::nn::CheckPoint;

--- a/server/bastionai_learning/src/optim/optimizer.rs
+++ b/server/bastionai_learning/src/optim/optimizer.rs
@@ -6,8 +6,8 @@ pub trait Optimizer {
     fn zero_grad(&mut self) -> Result<(), TchError>;
     /// Performs a single training step using the accumulated gradients.
     fn step(&mut self) -> Result<(), TchError>;
-    /// Checkpoints model during training
-    fn check_point(&mut self) -> Result<(), TchError>;
+    /// Returns contained parameters as [`Vec<u8>`].
+    fn into_bytes(&mut self) -> Result<Vec<u8>, TchError>;
 }
 
 impl Optimizer for COptimizer {
@@ -17,8 +17,7 @@ impl Optimizer for COptimizer {
     fn step(&mut self) -> Result<(), TchError> {
         COptimizer::step(self)
     }
-
-    fn check_point(&mut self) -> Result<(), TchError> {
+    fn into_bytes(&mut self) -> Result<Vec<u8>, TchError> {
         todo!()
     }
 }

--- a/server/bastionai_learning/src/optim/optimizer.rs
+++ b/server/bastionai_learning/src/optim/optimizer.rs
@@ -6,6 +6,8 @@ pub trait Optimizer {
     fn zero_grad(&mut self) -> Result<(), TchError>;
     /// Performs a single training step using the accumulated gradients.
     fn step(&mut self) -> Result<(), TchError>;
+    /// Checkpoints model during training
+    fn check_point(&mut self) -> Result<(), TchError>;
 }
 
 impl Optimizer for COptimizer {
@@ -15,5 +17,8 @@ impl Optimizer for COptimizer {
     fn step(&mut self) -> Result<(), TchError> {
         COptimizer::step(self)
     }
-}
 
+    fn check_point(&mut self) -> Result<(), TchError> {
+        todo!()
+    }
+}

--- a/server/bastionai_learning/src/optim/sgd.rs
+++ b/server/bastionai_learning/src/optim/sgd.rs
@@ -1,5 +1,5 @@
-use super::{initialize_statistics, log_checkpoint, Optimizer};
-use crate::nn::{CheckPoint, Parameters};
+use super::{initialize_statistics, Optimizer};
+use crate::nn::Parameters;
 use tch::{TchError, Tensor};
 
 /// Stochastic Gradient Descent Optimizer
@@ -19,12 +19,11 @@ pub struct SGD<'a> {
     nesterov: bool,
     statistics: Vec<Option<Tensor>>,
     pub parameters: Parameters<'a>,
-    chkpt: &'a mut CheckPoint,
 }
 
 impl<'a> SGD<'a> {
     /// Returns a new SGD optimizer to update given `parameters` using given `learning_rate`.
-    pub fn new(parameters: Parameters<'a>, chkpt: &'a mut CheckPoint, learning_rate: f64) -> Self {
+    pub fn new(parameters: Parameters<'a>, learning_rate: f64) -> Self {
         SGD {
             learning_rate: learning_rate,
             weight_decay: 0.,
@@ -33,7 +32,6 @@ impl<'a> SGD<'a> {
             nesterov: false,
             statistics: initialize_statistics(parameters.len()),
             parameters,
-            chkpt,
         }
     }
     /// Sets weight_decay.
@@ -96,10 +94,7 @@ impl<'a> Optimizer for SGD<'a> {
         })
     }
 
-    fn check_point(&mut self) -> Result<(), TchError> {
-        self.chkpt.append(&mut log_checkpoint(
-            self.parameters.into_named_inner().unwrap(),
-        ));
-        Ok(())
+    fn into_bytes(&mut self) -> Result<Vec<u8>, TchError> {
+        self.parameters.into_bytes()
     }
 }

--- a/server/bastionai_learning/src/serialization.rs
+++ b/server/bastionai_learning/src/serialization.rs
@@ -1,3 +1,5 @@
+use tch::TchError;
+
 fn read_le_usize(input: &mut &[u8]) -> usize {
     let (int_bytes, rest) = input.split_at(std::mem::size_of::<usize>());
     *input = rest;
@@ -60,5 +62,25 @@ impl Iterator for SizedObjectsBytes {
         } else {
             None
         }
+    }
+}
+
+#[derive(Debug)]
+pub struct BinaryModule(pub(crate) Vec<u8>);
+
+impl TryFrom<SizedObjectsBytes> for BinaryModule {
+    type Error = TchError;
+
+    fn try_from(mut value: SizedObjectsBytes) -> Result<Self, Self::Error> {
+        let object = value.next().ok_or(TchError::FileFormat(String::from(
+            "Invalid data, expected at least one object in stream.",
+        )))?;
+        Ok(BinaryModule(object))
+        // let vs = VarStore::new(Device::Cpu);
+        // Ok(Module {
+        //     c_module: TrainableCModule::load_data(&mut &object[..], vs.root())?,
+        //     var_store: vs,
+        //     dp_sgd_context: Arc::new(RwLock::new(None)),
+        // })
     }
 }

--- a/server/bastionai_learning/src/serialization.rs
+++ b/server/bastionai_learning/src/serialization.rs
@@ -76,11 +76,5 @@ impl TryFrom<SizedObjectsBytes> for BinaryModule {
             "Invalid data, expected at least one object in stream.",
         )))?;
         Ok(BinaryModule(object))
-        // let vs = VarStore::new(Device::Cpu);
-        // Ok(Module {
-        //     c_module: TrainableCModule::load_data(&mut &object[..], vs.root())?,
-        //     var_store: vs,
-        //     dp_sgd_context: Arc::new(RwLock::new(None)),
-        // })
     }
 }

--- a/server/protos/remote_torch.proto
+++ b/server/protos/remote_torch.proto
@@ -48,6 +48,8 @@ message TrainConfig {
     float eps = 7;
     float max_grad_norm = 8;
     float metric_eps = 9;
+    int32 per_n_step_checkpoint = 12;
+    bool per_epoch_checkpoint = 13;
     
     oneof optimizer {
         // The type of optimizer to be used during training.


### PR DESCRIPTION
This PR contains the updates and `server` and `client` to facilitate splitting both the code and data of the module.
The `modules` state in the BastionAI server is divided into `binaries` and `checkpoints`.
- `binaries` store the "code" of the model. From this object, a "trainable" version of the model can be created.
- `checkpoints` store checkpoints of the model, a.k.a, the "data". The last update is what is returned to the client when it requests to fetch a model.
- 
```rust
struct BastionAIServer {
    binaries: RwLock<HashMap<String, Artifact<BinaryModule>>>,
    checkpoints: RwLock<HashMap<String, Artifact<CheckPoint>>>,
    datasets: RwLock<HashMap<String, Artifact<Dataset>>>,
    runs: RwLock<HashMap<Uuid, Arc<RwLock<Run>>>>,
}
```
These are the new structures for `CheckPoint` and `BinaryModule`
```rust
pub struct BinaryModule(pub(crate) Vec<u8>);

pub struct CheckPoint {
    pub data: Vec<Vec<u8>>,
    pub private: bool,
}
```
